### PR TITLE
Fix typo in service examples

### DIFF
--- a/documentation/service/examples.md
+++ b/documentation/service/examples.md
@@ -16,7 +16,7 @@ Here are some example services:
     </service>
 
 
-## ipset
+## ipsec
 
     <?xml version="1.0" encoding="utf-8"?>
     <service>


### PR DESCRIPTION
The documentation for services includes examples. One of the examples is based of `ipsec.xml` but was incorrectly titled as "ipset" instaed of "ipsec". This commit fixes this typo.