### PR TITLE
Fix typo in documentation/service/examples.md

### DIFF
--- a/documentation/service/examples.md
+++ b/documentation/service/examples.md
@@ -16,7 +16,7 @@ Here are some example services:
     </service>
 
 
-## ipset
+## ipsec
 
     <?xml version="1.0" encoding="utf-8"?>
     <service>


### PR DESCRIPTION
Change example IPsec service definition heading from ipset to ipsec