### PR TITLE
fix: update Jekyll files and fix warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ bin
 vendor/ruby
 Gemfile.lock
 images/image_optim_cache.yml
+.jekyll-cache/
 .jekyll-metadata
 slim-pickins-jekyll-theme-master

--- a/Rakefile
+++ b/Rakefile
@@ -61,7 +61,7 @@ end
 
 # Ping Google and Yahoo to let them know you updated your site
 
-site = "www.YOUR-URL.com"
+site = "www.firewalld.org"
 
 desc 'Notify Google of the new sitemap'
 task :sitemapgoogle do
@@ -69,7 +69,7 @@ task :sitemapgoogle do
     require 'net/http'
     require 'uri'
     puts '* Pinging Google about our sitemap'
-    Net::HTTP.get('www.google.com', '/webmasters/tools/ping?sitemap=' + URI.escape('#{site}/sitemap.xml'))
+    Net::HTTP.get('www.google.com', '/webmasters/tools/ping?' + URI.encode_www_form("sitemap" => "#{site}/sitemap.xml"))
   rescue LoadError
     puts '! Could not ping Google about our sitemap, because Net::HTTP or URI could not be found.'
   end
@@ -81,7 +81,7 @@ task :sitemapbing do
     require 'net/http'
     require 'uri'
     puts '* Pinging Bing about our sitemap'
-    Net::HTTP.get('www.bing.com', '/webmaster/ping.aspx?siteMap=' + URI.escape('#{site}/sitemap.xml'))
+    Net::HTTP.get('www.bing.com', '/webmaster/ping.aspx?' + URI.encode_www_form("sitemap" => "#{site}/sitemap.xml"))
   rescue LoadError
     puts '! Could not ping Bing about our sitemap, because Net::HTTP or URI could not be found.'
   end

--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ kramdown:
 
 destination: _site
 
-gems:
+plugins:
   - jekyll-feed
   - jekyll-paginate
   - jekyll-seo-tag

--- a/_sass/foundation/util/_mixins.scss
+++ b/_sass/foundation/util/_mixins.scss
@@ -2,6 +2,8 @@
 // foundation.zurb.com
 // Licensed under MIT Open Source
 
+$-zf-size: null; // fix warning
+
 ////
 /// @group functions
 ////

--- a/blog/_posts/2018-07-24-nftables-backend.md
+++ b/blog/_posts/2018-07-24-nftables-backend.md
@@ -10,7 +10,7 @@ category: nftables
 Introduction
 ------------
 As noted in the [v0.6.0 release announcement]({% post_url
-2018-07-12-firewalld-0-6-0-release %}), firewalld recently gained support for
+/blog/2018-07-12-firewalld-0-6-0-release %}), firewalld recently gained support for
 using nftables as a firewall backend. This post will highlight why that's a
 good thing, how it affects firewalld, and how to start using it. The content
 here may be interesting to intermediate to advanced users of firewalld or

--- a/blog/_posts/2020-09-00-firewalld-0-9-0-release.md
+++ b/blog/_posts/2020-09-00-firewalld-0-9-0-release.md
@@ -12,9 +12,9 @@ A new release of firewalld, version 0.9.0, is available.
 This is a feature release. It also includes all bug fixes since v0.8.0.
 
 New features:
-- [AllowZoneDrifting]({% post_url 2020-01-31-allowzonedrifting %})
-- [Intra Zone Forwarding]({% post_url 2020-04-29-intra-zone-forwarding %})
-- [Policy Objects]({% post_url 2020-09-02-policy-objects-introduction %})
+- [AllowZoneDrifting]({% post_url /blog/2020-01-31-allowzonedrifting %})
+- [Intra Zone Forwarding]({% post_url /blog/2020-04-29-intra-zone-forwarding %})
+- [Policy Objects]({% post_url /blog/2020-09-02-policy-objects-introduction %})
 
 Statistics since v0.8.0:
 - 178 commits


### PR DESCRIPTION
Note: [slim-pickins-jekyll-theme](http://chrisanthropic.github.io/slim-pickins-jekyll-theme/) is no longer maintained