### PR TITLE
update: change Qt4 to Qt5

### DIFF
--- a/documentation/utilities/firewall-applet.md
+++ b/documentation/utilities/firewall-applet.md
@@ -7,7 +7,7 @@ firewall-applet is a tray applet for firewalld. It provides information about th
 
 There is a left and also right mouse button menu and also a tooltip with the active settings when moving the mouse over the icon.
 
-The applet has been ported over to Qt4 as the StatusIcon support in Gtk3 has been deprecated.
+The applet has been ported over to Qt5 as the StatusIcon support in Gtk3 has been deprecated.
 
 ## Limitations with Gnome3
 

--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ The separation of the runtime and permanent configuration makes it possible to d
  * Integration with Puppet
  * Command line clients for online and offline configuration
  * Graphical configuration tool using gtk3
- * Applet using Qt4
+ * Applet using Qt5
 
 ## Who is using it?
 


### PR DESCRIPTION
Updated pages that mention usage of Qt4 instead of Qt5,
did not change the blogs that mention the porting to Qt4
for historical purposes.

Fixes: #8