### PR TITLE
Fix mixed-up usage of in- and egress for policies

### DIFF
--- a/documentation/man-pages/firewalld.policies.html
+++ b/documentation/man-pages/firewalld.policies.html
@@ -46,10 +46,10 @@ title: firewalld.policies
                         netfilter (iptables/nftables) chains INPUT and OUTPUT.
                     </p><div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: disc; "><li class="listitem"><p>
                                 If used in the egress zones list it will apply to
-                                traffic on the INPUT chain.
+                                traffic on the OUTPUT chain.
                             </p></li><li class="listitem"><p>
                                 If used in the ingress zones list it will apply
-                                to traffic on the OUTPUT chain.
+                                to traffic on the INPUT chain.
                             </p></li></ul></div></li><li class="listitem"><p>ANY</p><p>
                         This symbolic zone behaves like a wildcard for the
                         ingress and egress zones. With the exception that it


### PR DESCRIPTION
In the man-pages for the firewalld.policies the usage of "ingress" and "egress" are mixed-up, so "ingress" is mentioned for the "OUTPUT" chain and "egress" is mentioned for the "INPUT" chain.
This commit fixes this so "ingress" is mentioned for the "INPUT" chain and "egress" is mentioned for the "OUTPUT" chain.